### PR TITLE
fix(no-deprecated=event-methods): allow ajax load calls

### DIFF
--- a/lib/rules/no-deprecated-event-methods.js
+++ b/lib/rules/no-deprecated-event-methods.js
@@ -77,6 +77,17 @@ module.exports = {
 
       const identifier = node.callee.property;
 
+      if (identifier.name === 'load') {
+        if (node.arguments.length > 0) {
+          if (node.arguments[0].type === "Literal") {
+            if (typeof node.arguments[0].value === 'string') {
+              return;
+            }
+          }
+        }
+
+      }
+
       const report = {
         node: identifier,
         messageId: 'no-deprecated-event-methods',

--- a/test/lib/rules/jquery-compat/no-deprecated-event-methods.js
+++ b/test/lib/rules/jquery-compat/no-deprecated-event-methods.js
@@ -26,6 +26,9 @@ ruleTester.run('jquery-compat/no-deprecated-event-methods', rules['no-deprecated
     },
     {
       code: '$("body").on("unload", handler)'
+    },
+    {
+      code: '$("body").load("string")'
     }
   ],
   invalid: [


### PR DESCRIPTION
Ajax loads were identified as deprecated event on load handler for
fixing