### PR TITLE
Test cases and fixes for some code that prevents linting

### DIFF
--- a/lib/rules/attr-select.js
+++ b/lib/rules/attr-select.js
@@ -56,7 +56,7 @@ module.exports = {
           args[0]
       )
 
-      if (!BANNED_ATTRS.includes(arg0.value)) { return }
+      if (!arg0 || !BANNED_ATTRS.includes(arg0.value)) { return }
 
       const sourceCode = context.getSourceCode();
 

--- a/lib/rules/no-attr-value.js
+++ b/lib/rules/no-attr-value.js
@@ -63,7 +63,7 @@ module.exports = {
         ? resolveIdentifier(args[0], context)
         : args[0]
 
-      if (arg0.type !== 'Literal' || arg0.value !== 'value') return
+      if (!arg0 || arg0.type !== 'Literal' || arg0.value !== 'value') return
 
       context.report({
         node: node.callee.property,

--- a/lib/rules/no-null-param.js
+++ b/lib/rules/no-null-param.js
@@ -62,7 +62,7 @@ module.exports = {
         argumentObject = argumentObject['data']
       }
 
-      if (typeof argumentObject !== "object") { return }
+      if (typeof argumentObject !== "object" || argumentObject === null) { return }
 
       let foundBadValue = badValueWalker(BANNED_VALUES)(argumentObject)
 

--- a/test/lib/rules/jquery-compat/attr-select.js
+++ b/test/lib/rules/jquery-compat/attr-select.js
@@ -30,6 +30,12 @@ ruleTester.run('jquery-compat/attr-select', rules['attr-select'], {
       },
       {
         code: `(true ? bar : $foo.model()).attr('${property}')`
+      },
+      {
+        code: `function foo(attr) { return $bar.attr(attr); }`
+      },
+      {
+        code: `$.each(["${property}"], function(i, attr) { if (element.attr(attr)) {} });`
       }
     ])
     .reduce((acc, next) => acc.concat(next))

--- a/test/lib/rules/jquery-compat/no-attr-value.js
+++ b/test/lib/rules/jquery-compat/no-attr-value.js
@@ -19,6 +19,9 @@ ruleTester.run('jquery-compat/no-attr-value', rules['no-attr-value'], {
     {
       code: `var name = "something-else";
         $(".foo").attr(name)`
+    },
+    {
+      code: `$.each(["name"], function(i, attr) { if (element.attr(attr)) {} });`
     }
   ],
   invalid: [

--- a/test/lib/rules/jquery-compat/no-null-param.js
+++ b/test/lib/rules/jquery-compat/no-null-param.js
@@ -22,6 +22,9 @@ ruleTester.run('jquery-compat/no-null-param', rules['no-null-param'], {
       code: `var data = { foo: null };
       data.foo = 42;
       $.ajax("hello", { data: data });`
+    },
+    {
+      code: `$.ajax({ data: null });`
     }
   ],
   invalid: [


### PR DESCRIPTION
Thanks for open sourcing this plugin! I ran it on the very big and old JavaScript codebase I am currently trying to upgrade and found a few pieces of code that caused exceptions and prevented the linting from completing. They mostly seem to be related to contexts where identifiers can't be resolved to a value.

Hopefully these changes are helpful, happy to revise if you have feedback.