### PR TITLE
fix: template literal parsing throwing exception

### DIFF
--- a/lib/utils/resolve.js
+++ b/lib/utils/resolve.js
@@ -7,6 +7,9 @@ const resolveObjectExpression = require('./resolve/objectExpression')
 const UNRESOLVED = require('./resolve/UNRESOLVED')
 
 const resolve = contextualResolver => (node, context) => {
+  // @TODO handle this edge case with literals
+  if (!node) { return undefined }
+
   // console.log(node)
   const result = (() => {
     switch (node.type) {

--- a/test/lib/rules/jquery-compat/no-trailing-text-in-html-strings.js
+++ b/test/lib/rules/jquery-compat/no-trailing-text-in-html-strings.js
@@ -2,7 +2,11 @@ const { RuleTester } = require('eslint')
 
 const rules = require('../../../../lib/rules')
 
-const ruleTester = new RuleTester()
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
 const now = Date.now()
 
@@ -39,6 +43,14 @@ ruleTester.run(
       }
     ],
     invalid: [
+      {
+        code: '$(`<h1>foo</h1> `)',
+        errors: [{
+          messageId: 'no-trailing-text-in-html-strings',
+          line: 1,
+          column: 3
+        }]
+      },
       {
         // jquery-migrate trims string before testing, but jquery-actual does not.
         code: '$("<h1>foo</h1> ")',


### PR DESCRIPTION
```
$ npx eslint $FILENAME
...
Cannot read property 'type' of undefined
Occurred while linting $FILENAME
```

Caused by the presence of [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in the referenced `$FILENAME`.